### PR TITLE
Add lecture slides for POSC320 Async

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,7 +521,88 @@ body {
     <div class="container">
       <div class="course-section">
         <h2><i class="fas fa-laptop me-2"></i>POSC 320 Asynchronous: Introduction to Public Administration</h2>
-        <p class="text-muted"><em>Course materials will be added here.</em></p>
+        <div class="lecture-grid">
+          <div class="lecture-item">
+            <h5>Module 10: Accountability</h5>
+            <p>Presentations and course materials for Module 10: Accountability.</p>
+            <a href="POSC320/pdf/md_slides/module_10_accountability.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 1: What Is PA?</h5>
+            <p>Presentations and course materials for Module 1: What Is PA?.</p>
+            <a href="POSC320/pdf/md_slides/module_1_WhatIsPA.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 2-1: Basics</h5>
+            <p>Presentations and course materials for Module 2-1: Basics.</p>
+            <a href="POSC320/pdf/md_slides/module_2-1_basics.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 2-2: Eras of PA</h5>
+            <p>Presentations and course materials for Module 2-2: Eras of PA.</p>
+            <a href="POSC320/pdf/md_slides/module_2-2erasofpa.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 3-1: What Govt Does</h5>
+            <p>Presentations and course materials for Module 3-1: What Govt Does.</p>
+            <a href="POSC320/pdf/md_slides/module_3-1_what_govt_does.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 3-2: Govt Functions</h5>
+            <p>Presentations and course materials for Module 3-2: Govt Functions.</p>
+            <a href="POSC320/pdf/md_slides/module_3-2_govt_functions.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 4-1: Org Theory</h5>
+            <p>Presentations and course materials for Module 4-1: Org Theory.</p>
+            <a href="POSC320/pdf/md_slides/module_4-1_orgtheory.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 4-2: Org Problems</h5>
+            <p>Presentations and course materials for Module 4-2: Org Problems.</p>
+            <a href="POSC320/pdf/md_slides/module_4-2_org_problems.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 5-1: Executive</h5>
+            <p>Presentations and course materials for Module 5-1: Executive.</p>
+            <a href="POSC320/pdf/md_slides/module_5-1_executive.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 5-2: Reform</h5>
+            <p>Presentations and course materials for Module 5-2: Reform.</p>
+            <a href="POSC320/pdf/md_slides/module_5-2_reform.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 6-1: Civil Service</h5>
+            <p>Presentations and course materials for Module 6-1: Civil Service.</p>
+            <a href="POSC320/pdf/md_slides/module_6-1_civilservice.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 6-2: Human Capital</h5>
+            <p>Presentations and course materials for Module 6-2: Human Capital.</p>
+            <a href="POSC320/pdf/md_slides/module_6-2_humancapital.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 7-1: Decision Making</h5>
+            <p>Presentations and course materials for Module 7-1: Decision Making.</p>
+            <a href="POSC320/pdf/md_slides/module_7-1_decisionmaking.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 7-2: Budgeting</h5>
+            <p>Presentations and course materials for Module 7-2: Budgeting.</p>
+            <a href="POSC320/pdf/md_slides/module_7-2_budgeting.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 8-1: Performance Implementation</h5>
+            <p>Presentations and course materials for Module 8-1: Performance Implementation.</p>
+            <a href="POSC320/pdf/md_slides/module_8-1_performance_implementation.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+          <div class="lecture-item">
+            <h5>Module 9: Regulation and Courts</h5>
+            <p>Presentations and course materials for Module 9: Regulation and Courts.</p>
+            <a href="POSC320/pdf/md_slides/module_9_regulationandcourts.pdf" class="btn btn-sm btn-primary">View PDF</a>
+          </div>
+        </div>
       </div>
     </div>
   </section>


### PR DESCRIPTION
This commit updates index.html to include links to lecture slides for the POSC320 Asynchronous course. The slides are sourced from the POSC320/pdf/md_slides/ directory.

The POSC 320 Asynchronous section in index.html now displays a grid of lecture items, each with a title derived from the PDF filename and a direct link to the presentation file.